### PR TITLE
Improve DateRangeSet::make

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -2,7 +2,7 @@ name: date-range
 type: php
 docroot: ""
 php_version: "8.2"
-webserver_type: apache-fpm
+webserver_type: generic
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Add `DateRangeSet::getCoveringDateRange()` method to get the minimal date 
   range covering all ranges in the set.
+* Improve efficiency of `DateRangeSet::make()` method when passing a `DateRange`
+  or `DateRangeSet` instance.
 
 ## [1.1.0] - 2025-11-21
 

--- a/src/DateRangeSet.php
+++ b/src/DateRangeSet.php
@@ -40,20 +40,23 @@ class DateRangeSet implements Arrayable
      * can either be a DateRange object or an array that can be converted to a
      * DateRange object), a single DateRange object, or null.
      *
-     * @param  Arrayable<array-key, DateRange|array<int, string|DateTimeInterface|null>>|iterable<array-key, DateRange|array<int, string|DateTimeInterface|null>>|DateRange|null  $ranges
+     * @param  Arrayable<array-key, DateRange|array<int, string|DateTimeInterface|null>>|iterable<array-key, DateRange|array<int, string|DateTimeInterface|null>>|DateRangeSet|DateRange|null  $ranges
      *
      * @throws InvalidArgumentException if the input is invalid.
      */
     public static function make(Arrayable|iterable|DateRange|null $ranges = []): self
     {
-        // To keep the order of the date ranges, we start with an empty set and add each range one by one.
-
         if ($ranges instanceof DateRange) {
-            $ranges = collect([$ranges]);
+            return new self(collect([$ranges]));
         }
 
-        /** @var Collection<int, DateRange> $ranges */
-        $ranges = collect($ranges)->map(function (mixed $range): DateRange {
+        if ($ranges instanceof DateRangeSet) {
+            return $ranges;
+        }
+
+        // Convert the input ranges to a collection of DateRange objects.
+        /** @var Collection<int, DateRange> $processedRanges */
+        $processedRanges = collect($ranges)->map(function (mixed $range): DateRange {
             if ($range instanceof DateRange) {
                 return $range;
             }
@@ -67,8 +70,9 @@ class DateRangeSet implements Arrayable
             throw new InvalidArgumentException('Invalid date range provided. Expected DateRange object or array.');
         });
 
+        // To keep the order of the date ranges, we start with an empty set and add each range one by one.
         $set = new self(collect());
-        foreach ($ranges as $range) {
+        foreach ($processedRanges as $range) {
             $set = $set->addDateRange($range);
         }
 

--- a/tests/DateRangeSetTest.php
+++ b/tests/DateRangeSetTest.php
@@ -3,6 +3,38 @@
 use Swis\DateRange\DateRange;
 use Swis\DateRange\DateRangeSet;
 
+it('creates from array', function () {
+    $dateRangeSet = DateRangeSet::make([
+        ['2021-01-01', '2021-01-31'],
+    ]);
+
+    expect($dateRangeSet->toArray())->toEqual([['2021-01-01', '2021-01-31']]);
+});
+
+it('creates from date range', function () {
+    $dateRangeSet = DateRangeSet::make(
+        DateRange::make(
+            createDate('2021-01-01'),
+            createDate('2021-01-31')
+        ),
+    );
+
+    expect($dateRangeSet->toArray())->toEqual([['2021-01-01', '2021-01-31']]);
+});
+
+it('creates from date range set', function () {
+    $dateRangeSet = DateRangeSet::make(
+        DateRange::make(
+            createDate('2021-01-01'),
+            createDate('2021-01-31')
+        ),
+    );
+
+    $dateRangeSet2 = DateRangeSet::make($dateRangeSet);
+
+    expect($dateRangeSet2->toArray())->toEqual([['2021-01-01', '2021-01-31']]);
+});
+
 it('converts to array', function () {
     $dateRangeSet = DateRangeSet::make([
         DateRange::make(


### PR DESCRIPTION
`DateRangeSet::make` was not very efficient when a `DateRange` or `DateRangeSet` was passed.

With a `DateRange` it first converted this to a collection with 1 item, then looped over this collection to verify if it was really a `DateRange` object. Then an empty `DateRangeSet` was constructed and the full `addDateRange` procedure was executed. This new version simply creates a `DateRangeSet` with the single DateRange object in it.

With a `DateRangeSet`, it was converted to a collection of `DateRanges` and then the `DateRangeSet` was rebuild by repeatedly running `addDateRange`. This new version simply returns the passed in object.